### PR TITLE
feat: GA4 incremental sync — resumable state + lookback_days for reprocessing

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -9,6 +9,7 @@ import backoff
 from google.analytics.data_v1beta.types import (
     DateRange,
     Metric,
+    OrderBy,
     RunReportRequest,
     RunReportResponse,
 )
@@ -245,11 +246,23 @@ class GoogleAnalyticsStream(Stream):
 
         """
         self.logger.info(f"Querying API for {self.tap_stream_id} with date range {state_filter} to {self.end_date}")
+        # Order by the `date` dimension ascending so the SDK can finalize
+        # incremental state progressively (see `is_sorted`). Reports without a
+        # `date` dimension keep the API's default order.
+        order_bys = []
+        if self.replication_key == "date":
+            order_bys = [
+                OrderBy(
+                    dimension=OrderBy.DimensionOrderBy(dimension_name="date"),
+                    desc=False,
+                )
+            ]
         request = RunReportRequest(
             property=f"properties/{self.property_id}",
             dimensions=report_definition["dimensions"],
             metrics=report_definition["metrics"],
             date_ranges=[DateRange(start_date=state_filter, end_date=self.end_date)],
+            order_bys=order_bys,
             limit=self.page_size,
             offset=(pageToken or 0) * self.page_size,
         )
@@ -264,6 +277,17 @@ class GoogleAnalyticsStream(Stream):
             "number": th.NumberType(),
         }
         return mapping.get(string_type, th.StringType())
+
+    @property
+    def is_sorted(self) -> bool:
+        """Whether records are guaranteed to arrive in replication-key order.
+
+        Reports keyed on the `date` dimension are ordered by `date` ascending in
+        `_query_api`, so the SDK finalizes incremental state progressively during the
+        sync. This makes a mid-sync failure (e.g. a GA4 quota 429) resumable from the
+        last date pulled instead of discarding the run's progress.
+        """
+        return self.replication_key == "date"
 
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.

--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -121,8 +121,15 @@ class GoogleAnalyticsStream(Stream):
         self.logger.info(f"State bookmark for {self.tap_stream_id}: {state_bookmark}")
         parsed = cast(datetime, parse(state_bookmark))
         parsed = parsed.replace(tzinfo=None)
-        if parsed < datetime(2019, 1, 1):
-            parsed = datetime(2019, 1, 1)
+        # Re-pull a lookback window before the bookmark to recapture GA4 data that
+        # is still being reprocessed (GA4 data can change for 24-48h). target-ducklake
+        # upserts on the date+dims PK, so re-pulled days are corrected, not duplicated.
+        lookback_days = self.config.get("lookback_days", 3)
+        parsed = parsed - timedelta(days=lookback_days)
+        # Never start earlier than the configured start_date or GA4's 2019 floor.
+        start_floor = cast(datetime, parse(self.config["start_date"]))
+        start_floor = start_floor.replace(tzinfo=None)
+        parsed = max(parsed, start_floor, datetime(2019, 1, 1))
         # state bookmarks need to be reformatted for API requests
         return datetime.strftime(parsed, "%Y-%m-%d")
 

--- a/tap_google_analytics/tap.py
+++ b/tap_google_analytics/tap.py
@@ -121,6 +121,16 @@ class TapGoogleAnalytics(Tap):
             th.StringType,
             description="The last record date to sync",
         ),
+        th.Property(
+            "lookback_days",
+            th.IntegerType,
+            description=(
+                "Number of days to re-extract before the last saved bookmark, to "
+                "recapture GA4 data still being reprocessed (GA4 data can change for "
+                "24-48h). Defaults to 3."
+            ),
+            default=3,
+        ),
     ).to_dict()
 
     def _initialize_credentials(self):


### PR DESCRIPTION
## Problem

Society Brands' GA4 syncs have been failing daily with GA4 Data API quota errors:

```
google.api_core.exceptions.ResourceExhausted: 429 Exhausted property tokens for a
project per hour.
```

Beyond the quota issue itself, there's a compounding problem: **when a run fails partway through, all of that run's progress is thrown away**, so the next run restarts from the last *fully completed* sync and can never catch up.

## Root cause of the lost progress

This tap pins `singer-sdk ^0.46.0`, whose resumability is gated on whether a stream declares itself **sorted**:

- The tap sets `self.replication_key = "date"` in `schema()` but **never sets `is_sorted`**, so it inherits the SDK default `is_sorted = False`.
- With `is_sorted = False`, `singer_sdk.helpers._state.increment_state` writes every bookmark update into a throwaway `progress_markers` dict — explicitly noted *"Progress is not resumable if interrupted"* — and only promotes it to the real `replication_key_value` in `_finalize_state()`, which runs **only after the stream loop completes**. A mid-sync failure discards it.
- The `RunReportRequest` in `_query_api` was built with **no `order_bys`**, so GA4 returned rows in its default (unsorted) order — which is why `is_sorted` couldn't simply be flipped on.

## Fix

All in `tap_google_analytics/client.py`:

1. **Order results by the `date` dimension ascending** in `_query_api`, gated on `replication_key == "date"` (reports without a `date` dimension are left in the API's default order). GA4's [`runReport`](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport) supports `orderBys` with a [`DimensionOrderBy`](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/OrderBy).
2. **Override `is_sorted`** to return `True` for date-keyed streams.

`check_sorted` defaults to `True`, so these two changes must ship together — the `order_bys` is exactly what guarantees the date ordering the SDK now relies on (otherwise it would raise `InvalidStreamSortException`). Offset/limit pagination walks GA4's deterministic ordered result set, so date order is preserved across pages.

With this, a sync interrupted partway through (e.g. by a quota 429) keeps the dates already pulled and resumes from there.

## Notes

- **Scope:** this fixes the *lost-progress* failure mode, **not** the underlying quota collision (that's being addressed separately by reviewing/staggering the customer's multiple GA syncs). Complementary changes.
- **No duplicate rows:** `target-ducklake` upserts on the primary key (the tap sets `primary_keys = dimensions`, which includes `date`), so re-pulling the inclusive boundary date on resume upserts rather than duplicates.
- **Pre-existing lint:** CI's `flake8` flags two long `logger.info` lines (151, 248) introduced by an earlier commit; this PR intentionally does not touch them.

## Verification

- `flake8` / `isort` / `pydocstyle` clean on the changed code; `black` leaves the new block unchanged.
- Smoke-tested the exact `OrderBy(dimension=OrderBy.DimensionOrderBy(dimension_name="date"), desc=False)` + `RunReportRequest(order_bys=[...])` construction against the pinned `google-analytics-data ~=0.18.8`.
- Full standard tap tests run in CI (require the `GA_CLIENT_SECRETS` service account).

## Update: also adds `lookback_days` (default 3)

This PR now also handles GA4's data-reprocessing lag. GA4 reprocesses recent data for **24-48 hours** after collection, so the most recent days' metrics keep changing (Google: *"Data processing can take 24-48 hours. During that time, data in your reports may change."* — [Data freshness](https://support.google.com/analytics/answer/11198161)). Previously the incremental sync started each run exactly at the saved bookmark, so a day's first (incomplete) numbers were never re-pulled once synced.

New `lookback_days` config setting (default **3**, in `tap.py`'s `config_jsonschema`) backs the API `start_date` off by N days from the bookmark in `_get_state_filter`, clamped so it never starts before the configured `start_date` or GA4's 2019 floor. Re-pulled days are upserted on the date+dimensions PK by `target-ducklake`, so corrected figures overwrite in place rather than duplicating. Set `lookback_days: 0` to disable.

Verified: date-math unit cases (first run clamps to `start_date`; steady state = bookmark − 3d; near-start and 2019-floor clamps; `lookback_days=0` is a no-op) all pass; lint clean on the new code.

## Fix: `check_sorted=False` on date streams (lookback + is_sorted conflict)

The first prod run surfaced a regression from combining `is_sorted=True` (commit 1) with the lookback window (commit 2):

```
singer_sdk.exceptions.InvalidStreamSortException: Unsorted data detected in stream.
Latest value '20260605' is smaller than previous max '20260608'.
```

For a **sorted** stream the SDK keeps the previous run's bookmark (`20260608`) live in state and asserts each incoming record is `>=` it. The lookback intentionally re-extracts older dates (`20260608 − 3 = 20260605`), so the first records of every run trip that assertion and the whole sync fails.

Fix: override `check_sorted` to `False` for date-keyed streams. `check_sorted` is consumed only by the SDK's `increment_state`, where `is_sorted=True, check_sorted=False` writes the bookmark directly (still progressive/resumable) and skips the ordering assertion. Since `_query_api` orders by `date` ascending, the bookmark still advances to the max by end of stream — we only drop the now-counterproductive "never goes backwards" check that the lookback overlap legitimately violates.

## Follow-up (separate PR)

To reach prod, bump the `tap-ga4` reference in `meltano-extract` to include this commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

