### PR TITLE
fix: tolerate lookback overlap in sort check, keep check_sorted on (completes PR #5)

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -15,6 +15,7 @@ from google.analytics.data_v1beta.types import (
 )
 from pendulum import parse
 from singer_sdk import typing as th
+from singer_sdk.exceptions import InvalidStreamSortException
 from singer_sdk.streams import Stream
 
 from tap_google_analytics.error import is_fatal_error
@@ -130,6 +131,10 @@ class GoogleAnalyticsStream(Stream):
         start_floor = cast(datetime, parse(self.config["start_date"]))
         start_floor = start_floor.replace(tzinfo=None)
         parsed = max(parsed, start_floor, datetime(2019, 1, 1))
+        # Remember this run's lower bound. Records on/after it are within the requested
+        # (lookback) window; anything older is genuinely out of order. Used by
+        # `_increment_stream_state` to tolerate the lookback overlap.
+        self._lookback_floor = parsed
         # state bookmarks need to be reformatted for API requests
         return datetime.strftime(parsed, "%Y-%m-%d")
 
@@ -295,6 +300,36 @@ class GoogleAnalyticsStream(Stream):
         last date pulled instead of discarding the run's progress.
         """
         return self.replication_key == "date"
+
+    def _increment_stream_state(
+        self, latest_record: dict, *, context: Optional[dict] = None
+    ) -> None:
+        """Advance incremental state, tolerating the intentional lookback overlap.
+
+        `check_sorted` stays on, so genuinely unsorted data still raises. But the
+        `lookback_days` window deliberately re-extracts dates older than the saved
+        bookmark, so the leading records of a run are smaller than the prior max and
+        trip `InvalidStreamSortException`. Swallow that exception only for records
+        inside the requested window (date >= this run's start_date floor); records
+        older than the floor are truly out of order and are re-raised. Swallowed
+        records simply don't advance the bookmark, so it stays at the max.
+        """
+        try:
+            super()._increment_stream_state(latest_record, context=context)
+        except InvalidStreamSortException:
+            floor = getattr(self, "_lookback_floor", None)
+            rk_value = latest_record.get(self.replication_key or "")
+            if floor is None or rk_value is None:
+                raise
+            if datetime.strptime(str(rk_value), "%Y%m%d") < floor:
+                raise
+            # Within the lookback window: an already-synced date re-pulled on purpose.
+            max_bookmark = self.get_context_state(context).get("replication_key_value")
+            self.logger.info(
+                f"{self.tap_stream_id}: lookback record {rk_value} is older than the "
+                f"max bookmark {max_bookmark} but within the lookback window; "
+                f"proceeding without advancing state."
+            )
 
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.


### PR DESCRIPTION
## ⚠️ Why this is needed — `main` is currently broken

PR #5 was merged at commit `a8c5775`, bringing in **resumable state** (`is_sorted=True`) and **`lookback_days`** — but **not** the follow-up fix for the conflict between them. As a result `main` now throws on every GA4 sync run:

```
singer_sdk.exceptions.InvalidStreamSortException: Unsorted data detected in stream.
Latest value '20260605' is smaller than previous max '20260608'.
```

(Confirmed in prod Composer logs for `GoogleAnalytics-SBIMaster` on 2026-06-09, all retries failing.) This PR adds the fix on top of the merged `main`.

## Root cause

For a **sorted** stream the SDK keeps the previous run's bookmark (`20260608`) live in state and asserts each incoming record is `>=` it. The `lookback_days` window intentionally re-extracts older dates (`20260608 − 3 = 20260605`), so the leading records of every run violate that assertion and the sync aborts.

## Fix — keep the sort check, exempt only the lookback window

We still want `check_sorted` active so genuinely unsorted data is caught. `check_sorted` is a property with no access to the current record, so the per-record decision goes in `_increment_stream_state` (where the SDK actually has the record):

- `_get_state_filter` stashes this run's lower bound (`start_date = bookmark − lookback_days`) as `self._lookback_floor`.
- `_increment_stream_state` catches `InvalidStreamSortException` and **swallows it only when the record's date is `>= _lookback_floor`** (i.e. inside the window we deliberately re-pulled). Records older than the floor are genuinely out of order and **still raise**.
- Swallowed records don't advance the bookmark, so it **stays at the max** during the overlap (no regression), then advances normally once records pass the prior bookmark. `is_sorted=True` is unchanged, so state is still finalized progressively (resumable).

## Verification

- Compiles; `flake8` (only pre-existing `logger.info` E501s), `isort`, `pydocstyle`, `black` all clean on the new code.
- SDK-level test against the real `singer_sdk.helpers._state.increment_state`:
  - overlap dates `20260605/06/07` → swallowed, bookmark holds at `20260608`
  - `20260608/09` → advance → final bookmark `20260609` (max, no regression)
  - out-of-window `20240101` (< floor) → correctly re-raises
- Full functional confirmation comes from the next prod run after the `meltano-extract` `tap-ga4` ref is bumped to include this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)