### PR TITLE
chore: log lookback overlap once per run per stream

### DIFF
--- a/tap_google_analytics/client.py
+++ b/tap_google_analytics/client.py
@@ -135,6 +135,8 @@ class GoogleAnalyticsStream(Stream):
         # (lookback) window; anything older is genuinely out of order. Used by
         # `_increment_stream_state` to tolerate the lookback overlap.
         self._lookback_floor = parsed
+        # Reset the once-per-run guard for the lookback-overlap log below.
+        self._lookback_overlap_logged = False
         # state bookmarks need to be reformatted for API requests
         return datetime.strftime(parsed, "%Y-%m-%d")
 
@@ -324,12 +326,18 @@ class GoogleAnalyticsStream(Stream):
             if datetime.strptime(str(rk_value), "%Y%m%d") < floor:
                 raise
             # Within the lookback window: an already-synced date re-pulled on purpose.
-            max_bookmark = self.get_context_state(context).get("replication_key_value")
-            self.logger.info(
-                f"{self.tap_stream_id}: lookback record {rk_value} is older than the "
-                f"max bookmark {max_bookmark} but within the lookback window; "
-                f"proceeding without advancing state."
-            )
+            # Log once per run per stream to avoid one line per overlapping record.
+            if not getattr(self, "_lookback_overlap_logged", False):
+                max_bookmark = self.get_context_state(context).get(
+                    "replication_key_value"
+                )
+                self.logger.info(
+                    f"{self.tap_stream_id}: lookback overlap — record {rk_value} is "
+                    f"older than the max bookmark {max_bookmark} but within the "
+                    f"lookback window; proceeding (further overlap records this run "
+                    f"are not logged)."
+                )
+                self._lookback_overlap_logged = True
 
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.


### PR DESCRIPTION
## What

Follow-up to PR #6. The lookback-overlap `logger.info` in `_increment_stream_state` previously fired **once per tolerated record**. For multi-dimension reports (e.g. `locations` = date × country) that's `lookback_days × cardinality` lines per run — potentially hundreds.

This gates it to fire **once per run per stream**:
- `_get_state_filter` (called once at run start, before any record) resets a per-instance flag `self._lookback_overlap_logged = False`.
- `_increment_stream_state` logs only the first tolerated overlap record per run, then sets the flag. The message now notes that further overlap records this run aren't logged.

Each stream is its own instance and these streams aren't partitioned (`context` is `None`), so a per-instance flag is effectively per-stream; resetting it per run makes it per-run-per-stream.

**Swallow behavior is unchanged** — overlap records are still tolerated (state not advanced) and out-of-window records (`date < _lookback_floor`) still re-raise.

## Verification

- `py_compile` OK; `flake8` (only pre-existing `logger.info` E501s), `isort`, `pydocstyle`, `black` all clean on the new code.
- SDK-level test against the real `singer_sdk.helpers._state.increment_state`:
  - 3 overlap records (`20260605/06/07`) in a run → **1** log line; bookmark ends at max `20260609`
  - out-of-window `20240101` (< floor) → still re-raises
  - next run (flag reset) → logs again; bookmark advances to `20260610`

🤖 Generated with [Claude Code](https://claude.com/claude-code)